### PR TITLE
Make output and error window heights customisable

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ the following custom vars to the desired value:
 
     The minimum height in lines of the output window when there are failing tests.
 
-- `kaocha-runner-details-win-max-height`
+- `kaocha-runner-output-win-max-height`
 
-    The maximum height in lines of the details window.
+    The maximum height in lines of the output window.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,22 @@ include a reset of your choice.
 Also, if you want to shave ~150ms from each test run, you can remove the require
 from the template. In that case, you'll have to require it yourself.
 
+You can also customise the tests, failure, and details window heights by setting
+the following custom vars to the desired value:
+
+- `kaocha-runner-ongoing-tests-win-min-height`
+
+The minimum height in lines of the output window. The window is show when tests
+are taking long to run, to show the ongoing progress from kaocha.
+
+- `kaocha-runner-failure-win-min-height`
+
+The minimum height in lines of the failure window.
+
+- `kaocha-runner-details-win-max-height`
+
+The maximum height in lines of the details window.
+
 ## License
 
 Copyright (C) 2019 Magnar Sveen

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ the following custom vars to the desired value:
 
 - `kaocha-runner-ongoing-tests-win-min-height`
 
-    The minimum height in lines of the output window when tests
-    are taking long to run, to show the ongoing progress from kaocha.
+    The minimum height in lines of the output window when tests are taking long
+    to run. This is to show the ongoing progress from kaocha.
 
 - `kaocha-runner-failure-win-min-height`
 

--- a/README.md
+++ b/README.md
@@ -88,21 +88,23 @@ include a reset of your choice.
 Also, if you want to shave ~150ms from each test run, you can remove the require
 from the template. In that case, you'll have to require it yourself.
 
+### Visual customisation
+
 You can also customise the tests, failure, and details window heights by setting
 the following custom vars to the desired value:
 
 - `kaocha-runner-ongoing-tests-win-min-height`
 
-The minimum height in lines of the output window. The window is show when tests
-are taking long to run, to show the ongoing progress from kaocha.
+    The minimum height in lines of the output window when tests
+    are taking long to run, to show the ongoing progress from kaocha.
 
 - `kaocha-runner-failure-win-min-height`
 
-The minimum height in lines of the failure window.
+    The minimum height in lines of the output window when there are failing tests.
 
 - `kaocha-runner-details-win-max-height`
 
-The maximum height in lines of the details window.
+    The maximum height in lines of the details window.
 
 ## License
 

--- a/kaocha-runner.el
+++ b/kaocha-runner.el
@@ -61,9 +61,9 @@ This is to show the ongoing progress from kaocha."
   :type 'integer
   :package-version '(kaocha-runner . "0.2.0"))
 
-(defcustom kaocha-runner-details-win-max-height
+(defcustom kaocha-runner-output-win-max-height
   16
-  "The maximum height in lines of the details window."
+  "The maximum height in lines of the output window."
   :group 'kaocha-runner
   :type 'integer
   :package-version '(kaocha-runner . "0.2.0"))
@@ -185,7 +185,7 @@ This is to show the ongoing progress from kaocha."
     (let ((case-fold-search nil))
       (re-search-forward kaocha-runner--fail-re nil t))
     (end-of-line)
-    (kaocha-runner--fit-window-snuggly min-height kaocha-runner-details-win-max-height)
+    (kaocha-runner--fit-window-snuggly min-height kaocha-runner-output-win-max-height)
     (kaocha-runner--recenter-top)))
 
 (defun kaocha-runner--testable-sym (ns test-name cljs?)

--- a/kaocha-runner.el
+++ b/kaocha-runner.el
@@ -48,16 +48,15 @@
 
 (defcustom kaocha-runner-ongoing-tests-win-min-height
   12
-  "The minimum height in lines of the output window.
-The window is show when tests are taking long to run, to show the
-ongoing progress from kaocha."
+  "The minimum height in lines of the output window when tests are taking long to run.
+This is to show the ongoing progress from kaocha."
   :group 'kaocha-runner
   :type 'integer
   :package-version '(kaocha-runner . "0.2.0"))
 
 (defcustom kaocha-runner-failure-win-min-height
   4
-  "The minimum height in lines of the failure window."
+  "The minimum height in lines of the output window when there are failing tests."
   :group 'kaocha-runner
   :type 'integer
   :package-version '(kaocha-runner . "0.2.0"))

--- a/kaocha-runner.el
+++ b/kaocha-runner.el
@@ -46,6 +46,29 @@
   :group 'kaocha-runner
   :type 'string)
 
+(defcustom kaocha-runner-ongoing-tests-win-min-height
+  12
+  "The minimum height in lines of the output window.
+The window is show when tests are taking long to run, to show the
+ongoing progress from kaocha."
+  :group 'kaocha-runner
+  :type 'integer
+  :package-version '(kaocha-runner . "0.2.0"))
+
+(defcustom kaocha-runner-failure-win-min-height
+  4
+  "The minimum height in lines of the failure window."
+  :group 'kaocha-runner
+  :type 'integer
+  :package-version '(kaocha-runner . "0.2.0"))
+
+(defcustom kaocha-runner-details-win-max-height
+  16
+  "The maximum height in lines of the details window."
+  :group 'kaocha-runner
+  :type 'integer
+  :package-version '(kaocha-runner . "0.2.0"))
+
 (defface kaocha-runner-success-face
   '((t (:foreground "green")))
   "Face used to highlight success messages."
@@ -163,7 +186,7 @@
     (let ((case-fold-search nil))
       (re-search-forward kaocha-runner--fail-re nil t))
     (end-of-line)
-    (kaocha-runner--fit-window-snuggly min-height 16)
+    (kaocha-runner--fit-window-snuggly min-height kaocha-runner-details-win-max-height)
     (kaocha-runner--recenter-top)))
 
 (defun kaocha-runner--testable-sym (ns test-name cljs?)
@@ -210,7 +233,7 @@ If BACKGROUND? is t, we don't message when the tests start running."
            (when (and (< 1 (- (float-time) start-time))
                       (not shown-details?))
              (setq shown-details? t)
-             (kaocha-runner--show-details-window original-buffer 12)))
+             (kaocha-runner--show-details-window original-buffer kaocha-runner-ongoing-tests-win-min-height)))
          (when err
            (kaocha-runner--insert kaocha-runner--err-buffer err))
          (when value
@@ -224,7 +247,7 @@ If BACKGROUND? is t, we don't message when the tests start running."
                (message "Kaocha run failed. See error window for details.")
                (switch-to-buffer-other-window kaocha-runner--err-buffer))))
          (when (and done? any-errors?)
-           (kaocha-runner--show-details-window original-buffer 4)))))))
+           (kaocha-runner--show-details-window original-buffer kaocha-runner-failure-win-min-height)))))))
 
 ;;;###autoload
 (defun kaocha-runner-hide-windows ()


### PR DESCRIPTION
I made the window heights customisable to reduce the scrolling within them when the output is too big.

I kept the original values as the default ones, and updated the README accordingly.